### PR TITLE
Исправление ошибки с удалением полной строки

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -64,7 +64,7 @@ $(document).ready(function() {
 
             // x,x -> remove whole line
             if (remainingConesInFirstLine.length == remainingConesInSecondLine.length) { 
-                return getRandomLine(remainingLines);
+                return getRandomConesFromLine(remainingConesInFirstLine, remainingConesInFirstLine.length)
             }
 
         } else if (numberOfRemainingLines == 3) {


### PR DESCRIPTION
Если на поле осталось две строки одинаковой длины, одна из строк, судя по комментарию в коде, должна полностью удаляться. Вместо этого строка просто выделяется и игра зависает, что не позволяет обыграть компьютер при использовании оптимального алгоритма.